### PR TITLE
Bump the npm_and_yarn group across 1 directory with 2 updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9410,13 +9410,13 @@
       }
     },
     "node_modules/remark-reading-time": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-reading-time/-/remark-reading-time-2.0.1.tgz",
-      "integrity": "sha512-fy4BKy9SRhtYbEHvp6AItbRTnrhiDGbqLQTSYVbQPGuRCncU1ubSsh9p/W5QZSxtYcUXv8KGL0xBgPLyNJA1xw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remark-reading-time/-/remark-reading-time-2.0.2.tgz",
+      "integrity": "sha512-ILjIuR0dQQ8pELPgaFvz7ralcSN62rD/L1pTUJgWb4gfua3ZwYEI8mnKGxEQCbrXSUF/OvycTkcUbifGOtOn5A==",
       "license": "ISC",
       "dependencies": {
         "estree-util-is-identifier-name": "^2.0.0",
-        "estree-util-value-to-estree": "^1.3.0",
+        "estree-util-value-to-estree": "^3.3.3",
         "reading-time": "^1.3.0",
         "unist-util-visit": "^3.1.0"
       }
@@ -9435,30 +9435,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-reading-time/node_modules/estree-util-value-to-estree": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/estree-util-value-to-estree/-/estree-util-value-to-estree-1.3.0.tgz",
-      "integrity": "sha512-Y+ughcF9jSUJvncXwqRageavjrNPAI+1M/L3BI3PyLp1nmgYTGUXU6t5z1Y7OWuThoDdhPME07bQU+d5LxdJqw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/remark-reading-time/node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/remark-reading-time/node_modules/unist-util-is": {


### PR DESCRIPTION
Bumps the npm_and_yarn group with 2 updates in the / directory: [estree-util-value-to-estree](https://github.com/remcohaszing/estree-util-value-to-estree) and [remark-reading-time](https://github.com/mattjennings/remark-reading-time).


Updates `estree-util-value-to-estree` from 1.3.0 to 3.3.3
- [Release notes](https://github.com/remcohaszing/estree-util-value-to-estree/releases)
- [Commits](https://github.com/remcohaszing/estree-util-value-to-estree/compare/v1.3.0...v3.3.3)

Updates `remark-reading-time` from 2.0.1 to 2.0.2
- [Release notes](https://github.com/mattjennings/remark-reading-time/releases)
- [Commits](https://github.com/mattjennings/remark-reading-time/compare/2.0.1...2.0.2)

---
updated-dependencies:
- dependency-name: estree-util-value-to-estree
  dependency-version: 3.3.3
  dependency-type: indirect
  dependency-group: npm_and_yarn
- dependency-name: remark-reading-time
  dependency-version: 2.0.2
  dependency-type: indirect
  dependency-group: npm_and_yarn
...

Signed-off-by: dependabot[bot] <support@github.com>